### PR TITLE
Support for macOS build using CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,8 +52,8 @@ output
 .idea
 
 # CMake generated build directories
-cmake-build-*
-CMakeLists.txt
+/build
+
 
 # macOS specific files
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ output
 # CMake generated build directories
 cmake-build-*
 CMakeLists.txt
+
+# macOS specific files
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ output
 
 # CMake generated build directories
 /build
+/install
+/package
 
 
 # macOS specific files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,20 @@ set_target_properties(espresso PROPERTIES
     OUTPUT_NAME_DEBUG "espressod"
 )
 
+# Install rules
+install(TARGETS espresso
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+)
+
+install(DIRECTORY include/ DESTINATION include)
+
+install(FILES espressoConfig.cmake DESTINATION lib/cmake/espresso)
+
+# Packaging support
+include(CPack)
+
 # Example: add executable if you have a main
 # add_executable(espresso_main src/main.cxx)
 # target_link_libraries(espresso_main espresso)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,3 +58,35 @@ include(CPack)
 if(APPLE)
     # Add macOS-specific flags or frameworks here
 endif()
+
+
+# Incorporate Google Tests
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/refs/heads/main.zip
+  DOWNLOAD_EXTRACT_TIMESTAMP true
+)
+FetchContent_MakeAvailable(googletest)
+
+
+enable_testing()
+
+add_executable(espresso_tests 
+  tests/TestArgs.cxx
+  # Add more test files here
+)
+
+target_include_directories(espresso_tests
+  PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/include/espresso
+)
+
+target_link_libraries(espresso_tests
+  PRIVATE
+    espresso
+    gtest_main
+) 
+
+add_test(NAME espresso_tests COMMAND espresso_tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.15)
+project(espresso LANGUAGES CXX)
+
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Include directories
+include_directories(
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/include/espresso
+)
+
+# Source files
+file(GLOB SRC_FILES
+    ${CMAKE_SOURCE_DIR}/src/*.cxx
+)
+
+# Header files (optional, for IDEs)
+file(GLOB HEADER_FILES
+    ${CMAKE_SOURCE_DIR}/include/*.hxx
+    ${CMAKE_SOURCE_DIR}/include/espresso/*.hxx
+)
+
+# Create static library (change to SHARED for DLL)
+add_library(espresso STATIC ${SRC_FILES} ${HEADER_FILES})
+# Precompiled header support (CMake 3.16+)
+target_precompile_headers(espresso PRIVATE src/stdhdr.hxx)
+
+# Optionally, set output directory
+set_target_properties(espresso PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+    OUTPUT_NAME "espresso"
+    OUTPUT_NAME_DEBUG "espressod"
+)
+
+# Example: add executable if you have a main
+# add_executable(espresso_main src/main.cxx)
+# target_link_libraries(espresso_main espresso)
+
+# Platform-specific settings (macOS example)
+if(APPLE)
+    # Add macOS-specific flags or frameworks here
+endif()

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple C++ library to help develop CLI tools easily and quickly by handling pr
 
 ## Introduction
 
-Have you ever found yourself building an application of tool only to get bogged down having to parse command-line args?
+Have you ever found yourself building an application or tool only to get bogged down having to parse command-line args?
 
 That's where the **espresso** library comes in. It makes it easy to specify what cmd-line switches you wish to support, whether they take a parameter and whether they're mandatory. It provides the ability to interrogate these switches, check they are present and retrieve their stringified or numeric values. In short, it handles these chores and allows you to concentrate on your applications features.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,42 @@ The software was originally developed on Windows 32-bit environments but was suc
 
 The original visual studio file were created Visual Studio 6.0 (which gives an indication as to the point when this 'tinkering' began) but were later ported to Visual Studio 2003, then Visual Studio 2005 and later Visual Studio 2008. There followed a fallow period before I again became re-acquainted with DevStudio using Visual Studio 2014 and then Visual Studio 2017. Most recently, I've ported to Visual Studio 2019. 
 
-The makefile is pretty trivial but works. Plans are afoot to adopt CMake. 
+
+## Building with CMake (macOS & Cross-Platform)
+
+The project now supports building with CMake, making it easy to build on macOS and other platforms.
+
+### Prerequisites
+
+- CMake (install via Homebrew: `brew install cmake`)
+- A C++17-compatible compiler (e.g., Apple Clang, GCC, MSVC)
+
+### Build Steps (macOS/Linux)
+
+```bash
+git clone https://github.com/donnachaforde/espresso.git
+cd espresso
+
+cmake -S ./ -B ./build 
+cmake --build ./build --config Release   # For release build (libespresso.a)
+cmake --build ./build --config Debug     # For debug build (libespressod.a)
+```
+
+The static library will be generated in `build/lib/` as `libespresso.a` (Release) and `libespressod.a` (Debug).
+
+### Build Steps (Windows)
+
+You can use CMake with Visual Studio 2019 or later:
+
+```powershell
+cmake -S . -B ./build
+cmake --build ./build --config Release   # libespresso.lib
+cmake --build ./build --config Debug     # libespressod.lib
+```
+
+### Notes
+- Precompiled headers are supported (using `stdhdr.hxx`).
+- The legacy makefile is still available for Unix-like systems.
 
 
 
@@ -61,5 +96,5 @@ Finally, there's a [blog](docs/README.md) where I try to capture thoughts on des
 
 Donnacha Forde
 
-January 2024
+August 2025
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ A simple C++ library to help develop CLI tools easily and quickly by handling pr
 
 Have you ever found yourself building an application or tool only to get bogged down having to parse command-line args?
 
-That's where the **espresso** library comes in. It makes it easy to specify what cmd-line switches you wish to support, whether they take a parameter and whether they're mandatory. It provides the ability to interrogate these switches, check they are present and retrieve their stringified or numeric values. In short, it handles these chores and allows you to concentrate on your applications features.
+That's where the **espresso** library comes in. It makes it easy to specify what cmd-line switches you wish to support, whether they take a parameter and whether they're mandatory. It provides the ability to interrogate these switches, check they're present and retrieve their stringified or numeric values. In short, it handles these chores so that you're free to concentrate on your applications features.
 
 
 The key features are:
 * A clear and simple API to define the arguments/switches your application supports.  
-* Automatic parsing of the arg-list and syntax checking to ensure the correct params and required params are being provided.
-* Provision of common default args, such as `--help`, `--version`, `--info` and `--usage`. 
-* Support for output to `stdout` by default but which is extensible so you can leverage it for your GUI app. 
+* Automatic parsing of the arg-list and syntax checking to ensure the correct params and required params have been provided.
+* Built-in support for default args - i.e. `--help`, `--version`, `--info` and `--usage`. 
+* Built-in support for `stdout` output (extensible so you can provide your own - e.g for your Windows GUI app). 
 
 
 
@@ -22,7 +22,7 @@ The key features are:
 
 Whats included?
 
-* libespresso -  static C++ library 
+* libespresso -  static C++ library (both Debug and Release versions)
 * header files - the espresso C++ header files 
 
 
@@ -34,6 +34,7 @@ What platforms are supported?
 * Windows 10 and 11 x64 (Visual C++ 2019)
 * macOS (cmake)
 
+### Additional Platforms
 
 Previously, the following platforms were supported for *gcc* using `make`. They haven't been exercised recently but there's every chance the makefile will still work. 
 
@@ -42,12 +43,15 @@ Previously, the following platforms were supported for *gcc* using `make`. They 
 * HP-UX
 * Red Hat Linux
 
-The software was originally developed on Windows 32-bit environments but was successfully ported and deployed to Unix/Linux environments. Later, the code was successfully built for x64 environments without issue. While the `makefile` is primitive, it should still work for UNIX environments. Most recently, it has been revised to build on macOS environments. 
+### History of Build Environments & Supported Platforms
+The original visual studio file were created Visual Studio 6.0, which provides a clue as to when the project idea originated. The project was later ported to Visual Studio 2003, then Visual Studio 2005 and later again Visual Studio 2008. There then followed a fallow period when I worked on other tech stacks before becoming re-acquainted with DevStudio using Visual Studio 2014 and then Visual Studio 2017. The most recent port was to Visual Studio 2019 though Visual Studio 2022 is overdue. 
+
+As the library was first built with Visual Studio 6.0, it only supported Windows 32-bit environments but was successfully ported and deployed to UNIX/Linux environments using a basic `makefile`. Later, the code was successfully built for x64 environments without issue. While the `makefile` is primitive, it should still work for UNIX environments. 
+
+Most recently, the build for macOS environments was revised to support `cmake`. 
 
 
-## Build Environments
 
-The original visual studio file were created Visual Studio 6.0 (which gives an indication as to the point when this 'tinkering' began) but were later ported to Visual Studio 2003, then Visual Studio 2005 and later Visual Studio 2008. There then followed a fallow period before I again became re-acquainted with DevStudio using Visual Studio 2014 and then Visual Studio 2017. Most recently, I've ported to Visual Studio 2019. 
 
 
 ## Building with CMake (macOS & Cross-Platform)
@@ -85,9 +89,6 @@ cmake --build ./build --config Release   # libespresso.lib
 cmake --build ./build --config Debug     # libespressod.lib
 ```
 
-### Notes
-- Precompiled headers are supported (using `stdhdr.hxx`).
-- The legacy makefile is still available for Unix-like systems.
 
 
 ## Further Info

--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # README - espresso lib 
-A simple C++ library to help develop CLI tools easily and quickly by handling command-line args. 
+A simple C++ library to help develop CLI tools easily and quickly by handling processing of command-line args. 
 
 
 ## Introduction
 
-Have you ever had a good idea for a CLI tool? But, when it comes to developing it, you get bogged down dealing with the intricacies of dealing with command line options? If so, then, **espresso** can alleviate that overhead by taking care of command-line options, help and versioning output, automatic error checking and handling, thereby freeing you up to concentrate on solving your utility. 
+Have you ever found yourself building an application of tool only to get bogged down having to parse command-line args?
+
+That's where the **espresso** library comes in. It makes it easy to specify what cmd-line switches you wish to support, whether they take a parameter and whether they're mandatory. It provides the ability to interrogate these switches, check they are present and retrieve their stringified or numeric values. In short, it handles these chores and allows you to concentrate on your applications features.
+
 
 The key features are:
-* A clear and simple API to define the arguments/switches your tool supports. 
-* Automatic parsing of the arglist and syntax checking to ensure the correct params are being provided.
-* Provision of common default args, such as --help, --version, --info and --usage. 
+* A clear and simple API to define the arguments/switches your application supports.  
+* Automatic parsing of the arg-list and syntax checking to ensure the correct params and required params are being provided.
+* Provision of common default args, such as `--help`, `--version`, `--info` and `--usage`. 
+* Support for output to `stdout` by default but which is extensible so you can leverage it for your GUI app. 
 
 
 
@@ -27,23 +31,23 @@ Whats included?
 
 What platforms are supported?
 
-* Windows 10 x64 (Visual C++ 2019)
-* macOS (gcc)
+* Windows 10 and 11 x64 (Visual C++ 2019)
+* macOS (cmake)
 
 
-Previously, the following platforms were supported for *gcc*. They haven't been exercised recently but there's every chance the makefile will still work. 
+Previously, the following platforms were supported for *gcc* using `make`. They haven't been exercised recently but there's every chance the makefile will still work. 
 
 * Solaris SunOS
 * AIX
 * HP-UX
 * Red Hat Linux
 
-The software was originally developed on Windows 32-bit environments but was successfully ported and deployed to Unix/Linux environments. Later, the code was successfully built for x64 environments without issue. While the `makefile` is primitive, it should still work for Unix/Linux environments. Most recently, it has been revised to build on macOS environments. 
+The software was originally developed on Windows 32-bit environments but was successfully ported and deployed to Unix/Linux environments. Later, the code was successfully built for x64 environments without issue. While the `makefile` is primitive, it should still work for UNIX environments. Most recently, it has been revised to build on macOS environments. 
 
 
 ## Build Environments
 
-The original visual studio file were created Visual Studio 6.0 (which gives an indication as to the point when this 'tinkering' began) but were later ported to Visual Studio 2003, then Visual Studio 2005 and later Visual Studio 2008. There followed a fallow period before I again became re-acquainted with DevStudio using Visual Studio 2014 and then Visual Studio 2017. Most recently, I've ported to Visual Studio 2019. 
+The original visual studio file were created Visual Studio 6.0 (which gives an indication as to the point when this 'tinkering' began) but were later ported to Visual Studio 2003, then Visual Studio 2005 and later Visual Studio 2008. There then followed a fallow period before I again became re-acquainted with DevStudio using Visual Studio 2014 and then Visual Studio 2017. Most recently, I've ported to Visual Studio 2019. 
 
 
 ## Building with CMake (macOS & Cross-Platform)
@@ -57,11 +61,14 @@ The project now supports building with CMake, making it easy to build on macOS a
 
 ### Build Steps (macOS/Linux)
 
+Clone the repo.
 ```bash
 git clone https://github.com/donnachaforde/espresso.git
 cd espresso
-
-cmake -S ./ -B ./build 
+```
+Trigger the CMake 'generate' and 'build' steps.
+```bash
+cmake -S ./src -B ./build 
 cmake --build ./build --config Release   # For release build (libespresso.a)
 cmake --build ./build --config Debug     # For debug build (libespressod.a)
 ```
@@ -73,7 +80,7 @@ The static library will be generated in `build/lib/` as `libespresso.a` (Release
 You can use CMake with Visual Studio 2019 or later:
 
 ```powershell
-cmake -S . -B ./build
+cmake -S ./src -B ./build
 cmake --build ./build --config Release   # libespresso.lib
 cmake --build ./build --config Debug     # libespressod.lib
 ```
@@ -83,18 +90,28 @@ cmake --build ./build --config Debug     # libespressod.lib
 - The legacy makefile is still available for Unix-like systems.
 
 
+## Further Info
 
-## Examples
-Check out [espresso tools](https://github.com/donnachaforde/espresso-tools) for example code that uses Espresso lib. There is also a [Developer Guide](docs/Developer-Guide.md) that mas more info on how to use the library to get you up and running quickly. 
+### Developer Guide
+The [Developer Guide](docs/Developer-Guide.md) guide will walk you through how to incorporate the library into your project and how to exercise the code. 
 
-Finally, there's a [blog](docs/README.md) where I try to capture thoughts on design as the solution evolves. 
+
+
+
+### Examples
+To see examples of how the **espresso** library is used in anger, check out [espresso tools](https://github.com/donnachaforde/espresso-tools), which is a collection of simple CLI utilities. 
+
+### Blog
+
+There is a [blog](docs/README.md) about the design of the **espresso** library that describes how its design evolved. 
+
+
+
+
 
 ***
 
-
-
-
 Donnacha Forde
 
-August 2025
+_Last updated:_ September 2025
 

--- a/docs/Developer-Guide.md
+++ b/docs/Developer-Guide.md
@@ -34,14 +34,7 @@ Enable as follows:
 > Of course, these macros must be defined before Crucial information necessary for users to succeed.
 
 
-### Build Version
 
-The version of the library is defined within the `<espresso.hxx>` header and publicly accessible as:
-
-```cpp
-espresso::BUILD_VERSION
-```
-This is a string you can reference if you wish. 
 
 
 

--- a/docs/Developer-Guide.md
+++ b/docs/Developer-Guide.md
@@ -70,8 +70,12 @@ Shortcut switches are also support as 'aliases'
 
 Next, create an Argument Manager and 'parse' the args. 
 
-	ArgMgr argMgr(args); 
-	argMgr.parseAndProcessArgs(); 
+	ArgManager argMgr = ArgManagerFactory::createInstance();
+	int nRetVal = argMgr.parseAndProcessArgs(args);
+	if (nRetVal != 0)
+	{
+		::exit(0);
+	}
 
 You can interogate the Arg-Manager about args you expect, etc. 
 

--- a/docs/Developer-Guide.md
+++ b/docs/Developer-Guide.md
@@ -1,32 +1,50 @@
 # Developer's Guide - espresso lib 
-Additional info about using the espresso library. 
+This is your guide to including the espresso library into your project and using its features. 
 
-***
 ## Compiling
 
-The easiest way to start using the library is to #include <espresso.hxx> header file. In turn, it #includes all the constituent parts. 
+All the features of the espresso library can be utilized by pulling in the top-level header. 
 
+```cpp
+#include <espresso.hxx>
+using namespace espresso; 
+```
 
-### namespace
-All articles within the espresso library are contained within the 'espresso' namespace.
+> [!NOTE]  
+> All artifacts in the library are contained within the `espresso` namespace. 
+ 
 
+### Library Macros
+The library has just a couple of macros that exist for developer flexibility. First, the library headers disable some common C++ compiler warnings (for the sake of clear build output) but you might not want it to do that. Defining `ESPRESSO_ENABLE_WARNINGS` ensures these compile errors won't be suppressed. 
 
-### macros
-All espresso macros must be #defined before <espresso.hxx> is #included. 
-| macro| Default |Purpose |
+Second, it can print additional information about the build to `stdout` during compilation. Defining `ESPRESSO_ENABLE_TRACING` enables this logging. 
+
+| Macro| Default |Purpose |
 |----------|----------|----------|
-|  ESPRESSO_ENABLE_WARNINGS| Disabled| Defining this macro will ensure specific certain compiler warnings are not disabled.|
-|  ESPRESSO_ENABLE_TRACING|  Disabled | Defining this macro ensure compilation notes and todo messages are written to the output window.|
+|  ESPRESSO_ENABLE_WARNINGS| Disabled| Defining this macro will ensure certain compiler warnings are not disabled.|
+|  ESPRESSO_ENABLE_TRACING|  Disabled | Defining this macro ensures compilation notes and todo messages are written to the output window.|
+
+Enable as follows:
+```cpp
+#define ESPRESSO_ENABLE_WARNINGS
+#define ESPRESSO_ENABLE_TRACING
+```
+
+> [!IMPORTANT]  
+> Of course, these macros must be defined before Crucial information necessary for users to succeed.
+
+
+### Build Version
+
+The version of the library is defined within the `<espresso.hxx>` header and publicly accessible as:
+
+```cpp
+espresso::BUILD_VERSION
+```
+This is a string you can reference if you wish. 
 
 
 
-
-### version
-
-The version number of the library is defined within the <espresso.hxx> header, which is publicly accessible as:
-
-		espresso::BUILD_VERSION 
-***
 ## Linking
 
 Add the libespresso library to your list of additional libraries and add the location path to your list of included directories. 
@@ -41,57 +59,129 @@ Note that libespresso uses the convention as follows:
 ***
 ## Coding
 
-Using the library for CMD-line argument parsing is pretty straightforward. Simply create an instance of the arg-manager, add default switches, add your own custom switches and then parse the argv list. 
+Using the library for cmd-line argument parsing is pretty straightforward. Simply create an instance of the arg-manager, add default switches, add your own custom switches and then parse the argv list. 
+
+### Initialization & Specification
+
+First, declare an instance of `Args`, as follows:
+```cpp
+Args args(argc, 
+		  argv, 
+		  "programName", 
+		  "Add your description here.", 
+		  "0.9.0-beta", 
+		  "Author's name", 
+		  "2025", 
+		  "contact email"); 	# or your preferred communication choice
+```
+
+You specify the program name and brief description, the version and author, the copyright year and any contact details for bugs or support. These details will be will be used when displaying `--help` or `--usage` information. 
 
 
-	Args args(argc, 
-			  argv, 
-			  "programName", 
-			  "Add your description here.", 
-			  "0.9.0-beta", 
-			  "Author's name", 
-			  "2021", 
-			  "@TwitterHandle");
+Next, most CLI applications react to the cmd-line args `--help`, `--usage`, `--info` and `--version` and you can leverage the built-in support for this by telling it you want to add these default switches.  
 
-You will most likely want to include support for cmd-line args like 'help' and 'version' and these are already availble by adding defaults, like this. 
-
-	args.addDefaults();
-
-Next, specify your own cmd-line arguments. Provide the name, the type, a description, whether the argument is mandatory or not and whether the arg/switch requires a target (e.g. --file filename.ext)
-
-	args.add("file",	Arg::STRING,	"Filename to modify.", true, "filename");
-	args.add("text",	Arg::NOARG,		"Display text only.");
+```cpp
+args.addDefaults();
+```
 
 
-Shortcut switches are also support as 'aliases'
+Then, specify your own cmd-line arguments. Provide the name, the type, a description, whether the argument is mandatory or not and whether the arg/switch requires a target (e.g. ``--file filename.ext``)
 
-	args.addAlias("columns", 'c');
-	args.addAlias("file", 'f');
+```cpp
+args.add("file",	Arg::STRING,	"Filename to modify.", true, "filename");
+args.add("text",	Arg::NOARG,		"Display text only.");
+args.add("count",	Arg::INTEGER,	"Number of lines of text to display.");
+```
 
-Next, create an Argument Manager and 'parse' the args. 
+You may well want to add support for shortcut switches, referred to as 'aliases'
 
-	ArgManager argMgr = ArgManagerFactory::createInstance();
-	int nRetVal = argMgr.parseAndProcessArgs(args);
-	if (nRetVal != 0)
-	{
-		::exit(0);
-	}
+```cpp
+args.addAlias("text", 't');
+args.addAlias("file", 'f');
+args.addAlias("count", 'c');
+```
 
-You can interogate the Arg-Manager about args you expect, etc. 
+> [!WARNING]  
+> The characters 'v', 'i', 'h' and 'u' are automatically specified for the default switches. 
 
-	// check display preferences
-	if (args.isPresent("text"))
-	{
-		.
-		.
-		.
-	}
-	
+
+The nature of your CLI may be that it requires a target and you can info the library to enforce that. If the target isn't present, it'll print the usage output to remind the user of what's needed. 
+
+```cpp
+args.requireTarget();
+```
+
+Finally, create an instance of the `ArgManager` and parse the args. 
+
+```cpp
+ArgManager argMgr = ArgManagerFactory::createInstance();
+int nRetVal = argMgr.parseAndProcessArgs(args);
+if (nRetVal != 0)
+{
+	::exit(0);
+}
+```
+
+
+### Using and Interrogating
+
+Now, you can interrogate this object about args you expect to be present, etc. 
+
+```cpp
+// check display preferences
+if (args.isPresent("text"))
+{
+	.
+	.
+	.
+}
+```
+
+Or, use the alias character.
+```cpp
+// check display preferences
+if (args.isPresent('t'))
+{
+	.
+	.
+	.
+}
+```
+
+In fact, there is convenient way to check that all your required args are present before you start processing. 
+
+```cpp
+if (args.isRequiredArgsPresent())
+{
+	// we're good to go...
+}
+```
+
+
+You can check that a value has been supplied and obtain the stringified or numeric representation of the associated value.
+
+```cpp
+String strFilename;
+if (args.isPresent("file") && args.isValueSupplied("file"))
+{
+	strFilename = args.getStringValue("file");
+}
+
+int nNumLines = 0; 
+if (args.isPresent("--count") && args.isValueSupplied("count"))
+{
+	nNumLines = args.getNumericValue("count");
+}
+```
+
+
+
+
 	
 ***
-Donnacha Forde - Espresso Library
+Donnacha Forde
 
-1995-2021
+_Author of the Espresso library 1995-2025_
 
 
 

--- a/espressoConfig.cmake
+++ b/espressoConfig.cmake
@@ -1,0 +1,29 @@
+# espressoConfig.cmake - CMake package configuration file for espresso
+
+# Set the include directory
+set(espresso_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/../include")
+
+# Set the library directory
+set(espresso_LIBRARY_DIR "${CMAKE_CURRENT_LIST_DIR}/../lib")
+
+# Set the library file (Release by default)
+set(espresso_LIBRARIES "${espresso_LIBRARY_DIR}/libespresso.a")
+
+# Optionally, set the debug library
+if(EXISTS "${espresso_LIBRARY_DIR}/libespressod.a")
+    set(espresso_LIBRARIES_DEBUG "${espresso_LIBRARY_DIR}/libespressod.a")
+endif()
+
+# Provide an imported target for easy linking
+if(NOT TARGET espresso::espresso)
+    add_library(espresso::espresso STATIC IMPORTED)
+    set_target_properties(espresso::espresso PROPERTIES
+        IMPORTED_LOCATION "${espresso_LIBRARIES}"
+        INTERFACE_INCLUDE_DIRECTORIES "${espresso_INCLUDE_DIR}"
+    )
+    if(DEFINED espresso_LIBRARIES_DEBUG)
+        set_target_properties(espresso::espresso PROPERTIES
+            IMPORTED_LOCATION_DEBUG "${espresso_LIBRARIES_DEBUG}"
+        )
+    endif()
+endif()

--- a/espressoConfig.cmake
+++ b/espressoConfig.cmake
@@ -1,10 +1,11 @@
 # espressoConfig.cmake - CMake package configuration file for espresso
 
-# Set the include directory
-set(espresso_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/../include")
 
-# Set the library directory
-set(espresso_LIBRARY_DIR "${CMAKE_CURRENT_LIST_DIR}/../lib")
+
+# Use relative paths for in-source builds
+get_filename_component(_prefix "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+set(espresso_INCLUDE_DIR "${_prefix}/include")
+set(espresso_LIBRARY_DIR "${_prefix}/lib")
 
 # Set the library file (Release by default)
 set(espresso_LIBRARIES "${espresso_LIBRARY_DIR}/libespresso.a")

--- a/src/ArgManager.cxx
+++ b/src/ArgManager.cxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright ï¿½ 1993-2020, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.
@@ -175,7 +175,7 @@ void ArgManager::onArgError(const Args& args, const string strInvalidOption)
 //
 //					1 to indicate a successful parse and an auto handled arg
 //
-//					0 to indicate a succesful parse but without any auto handled args
+//					0 to indicate a successful parse but without any auto handled args
 //
 // Notes          : @todo This needs to be rewritten to (probably) just return a bool. As it stands, 
 // and test such as if (!ParseAndProcessArgs()) will translate to 'false' when we return -1. 

--- a/tests/TestArgs.cxx
+++ b/tests/TestArgs.cxx
@@ -1,0 +1,60 @@
+#include <gtest/gtest.h>
+#include <espresso.hxx>
+using namespace espresso;
+
+TEST(ArgsTest, GetProgramName)
+{
+    const string strProgramName = "myprog";
+    Args args(0, nullptr, strProgramName, "desc", "0.1", "author", "2025", "@handle");
+    EXPECT_EQ(args.getProgramName(), strProgramName);
+}
+
+TEST(ArgsTest, GetProgramDescription) 
+{
+    const string strProgramDescription = "desc.";
+    Args args(0, nullptr, "test", strProgramDescription, "0.1", "author", "2025", "@handle");
+    EXPECT_EQ(args.getProgramDescription(), strProgramDescription);
+}
+
+TEST(ArgsTest, GetVersion) 
+{
+    const string strVersion = "1.2.3";
+    Args args(0, nullptr, "test", "desc", strVersion, "author", "2025", "@handle");
+    EXPECT_EQ(args.getVersion(), strVersion);
+}
+
+
+TEST(ArgsTest, GetYearAndOwner)
+{
+    const string strYear = "2025";
+    const string strCopyrightOwner = "John Smith";
+    string strCopyrightMessage = "Copyright " + strYear + ", " + strCopyrightOwner + ". All rights reserved.";
+
+    Args args(0, nullptr, "test", "desc", "0.1", strCopyrightOwner, strYear, "@handle");
+    EXPECT_EQ(args.getCopyrightNotice(), strCopyrightMessage);
+}
+
+TEST(ArgsTest, GeBugReportingHandle)
+{
+    const string strHandle = "@janedoe";
+    string strMessage = "Report bugs to " + strHandle + ".";
+    Args args(0, nullptr, "test", "desc", "0.1", "author", "2025", strHandle);
+    EXPECT_EQ(args.getBugReportingInstructions(), strMessage);
+}
+
+// TEST(ArgsTest, DefaultHelpPresent) 
+// {
+//     Args args(0, nullptr, "test", "desc", "0.1", "author", "2025", "@handle");
+//     args.addDefaults();
+
+// 	ArgManager argMgr = ArgManagerFactory::createInstance();
+// 	int nRetVal = argMgr.parseAndProcessArgs(args);
+// 	if (nRetVal != 0)
+// 	{
+// 		::exit(0);
+// 	}    
+
+//     EXPECT_TRUE(args.isPresent("help"));
+// }
+
+

--- a/tests/TestArgs.cxx
+++ b/tests/TestArgs.cxx
@@ -2,21 +2,21 @@
 #include <espresso.hxx>
 using namespace espresso;
 
-TEST(ArgsTest, GetProgramName)
+TEST(ArgsTest, GetProgramNameReturnsExpectedName)
 {
     const string strProgramName = "myprog";
     Args args(0, nullptr, strProgramName, "desc", "0.1", "author", "2025", "@handle");
     EXPECT_EQ(args.getProgramName(), strProgramName);
 }
 
-TEST(ArgsTest, GetProgramDescription) 
+TEST(ArgsTest, GetProgramDescriptionReturnsExpectedDescription) 
 {
     const string strProgramDescription = "desc.";
     Args args(0, nullptr, "test", strProgramDescription, "0.1", "author", "2025", "@handle");
     EXPECT_EQ(args.getProgramDescription(), strProgramDescription);
 }
 
-TEST(ArgsTest, GetVersion) 
+TEST(ArgsTest, GetVersionReturnsExpectedVersion) 
 {
     const string strVersion = "1.2.3";
     Args args(0, nullptr, "test", "desc", strVersion, "author", "2025", "@handle");
@@ -24,7 +24,7 @@ TEST(ArgsTest, GetVersion)
 }
 
 
-TEST(ArgsTest, GetYearAndOwner)
+TEST(ArgsTest, GetCopyrightDetailsReturnsExpectedCopyrightYearAndOwner)
 {
     const string strYear = "2025";
     const string strCopyrightOwner = "John Smith";
@@ -34,7 +34,7 @@ TEST(ArgsTest, GetYearAndOwner)
     EXPECT_EQ(args.getCopyrightNotice(), strCopyrightMessage);
 }
 
-TEST(ArgsTest, GeBugReportingHandle)
+TEST(ArgsTest, GeBugReportingInstructionsReturnsExpectedContact)
 {
     const string strHandle = "@janedoe";
     string strMessage = "Report bugs to " + strHandle + ".";
@@ -42,19 +42,66 @@ TEST(ArgsTest, GeBugReportingHandle)
     EXPECT_EQ(args.getBugReportingInstructions(), strMessage);
 }
 
-// TEST(ArgsTest, DefaultHelpPresent) 
-// {
-//     Args args(0, nullptr, "test", "desc", "0.1", "author", "2025", "@handle");
-//     args.addDefaults();
 
-// 	ArgManager argMgr = ArgManagerFactory::createInstance();
-// 	int nRetVal = argMgr.parseAndProcessArgs(args);
-// 	if (nRetVal != 0)
-// 	{
-// 		::exit(0);
-// 	}    
+TEST(ArgsTest, TargetRequiredNotPresentBeforehand) 
+{
+    Args args(0, nullptr, "test", "desc", "0.1", "author", "2025", "@handle");
+    EXPECT_FALSE(args.isTargetPresent());
+}
 
-//     EXPECT_TRUE(args.isPresent("help"));
-// }
+TEST(ArgsTest, TargetShouldBeAnEmptyStringBeforehand) 
+{
+    Args args(0, nullptr, "test", "desc", "0.1", "author", "2025", "@handle");
+    EXPECT_EQ(args.getTarget(), "");
+}
+
+TEST(ArgsTest, TargetPresentShouldBeFalseBeforeParsing) 
+{
+    Args args(0, nullptr, "test", "desc", "0.1", "author", "2025", "@handle");
+    EXPECT_FALSE(args.isTargetRequired());
+}
+
+TEST(ArgsTest, TargetShouldBeAnEmptyStringBeforeParsing) 
+{
+    Args args(0, nullptr, "test", "desc", "0.1", "author", "2025", "@handle");
+    EXPECT_EQ(args.getTarget(), "");
+}
+
+TEST(ArgsTest, InvalidOptionShouldBeEmptyStringBeforeParsing) 
+{
+    Args args(0, nullptr, "test", "desc", "0.1", "author", "2025", "@handle");
+    EXPECT_EQ(args.getInvalidOption(), "");
+}
+
+TEST(ArgsTestPostSetup, GetUsageReturnsExpectedKeywords)
+{
+    Args args(0, nullptr, "myprog", "A test program", "1.0", "John Smith", "2025", "bugs@example.com");
+    args.add("--input", Arg::type_t::STRING, true, "Input file");
+    args.add("--output", Arg::type_t::STRING, false, "Output file");
+    args.addDefaults();
+
+    std::string usage = args.getUsage();
+
+    // Check that usage contains expected switches and program name
+    EXPECT_NE(usage.find("myprog"), std::string::npos);
+    EXPECT_NE(usage.find("Usage:"), std::string::npos);
+    EXPECT_NE(usage.find("Usage"), std::string::npos);
+}
+
+TEST(ArgsTestPostSetup, GetUsageReturnsRequiredArgs)
+{
+    Args args(0, nullptr, "myprog", "A test program", "1.0", "John Smith", "2025", "bugs@example.com");
+    args.add("--required", Arg::type_t::STRING, true, "Input file");
+    args.add("--optional", Arg::type_t::STRING, false, "Output file");
+
+    std::string usage = args.getUsage();
+
+    EXPECT_NE(usage.find("required"), std::string::npos);
+    EXPECT_NE(usage.find("optional"), std::string::npos);
+}
+
+
+
+
 
 


### PR DESCRIPTION
Added support for building on macOS using CMake and revised README documentation and Developer Guide. 

- Added cmake file, tested on Apple Silicon. 
- Added initial support for Unit Testing using GTest. 
- Revised and updated documentation. 

