### PR TITLE
Updated macOS build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,8 @@ endif()
 
 
 # Incorporate Google Tests
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+set(INSTALL_GMOCK OFF CACHE BOOL "" FORCE)
 include(FetchContent)
 FetchContent_Declare(
   googletest
@@ -83,10 +85,8 @@ target_include_directories(espresso_tests
     ${CMAKE_SOURCE_DIR}/include/espresso
 )
 
-target_link_libraries(espresso_tests
-  PRIVATE
-    espresso
-    gtest_main
+target_link_libraries(espresso_tests PRIVATE espresso
+                                             gtest_main
 ) 
 
 add_test(NAME espresso_tests COMMAND espresso_tests)

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ You can use CMake with Visual Studio 2019 or later:
 
 ```powershell
 cmake -S ./src -B ./build
-cmake --build ./build --config Release   # libespresso.lib
-cmake --build ./build --config Debug     # libespressod.lib
+cmake --build ./build --target espresso --config Release   # libespresso.lib
+cmake --build ./build --target espresso --config Debug     # libespressod.lib
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ cd espresso
 ```
 Trigger the CMake 'generate' and 'build' steps.
 ```bash
-cmake -S ./src -B ./build -DCMAKE_BUILD_TYPE=Release # for release build
-cmake -S ./src -B ./build -DCMAKE_BUILD_TYPE=Debug   # for debug build
+cmake -S ./ -B ./build -DCMAKE_BUILD_TYPE=Release # for release build
+cmake -S ./ -B ./build -DCMAKE_BUILD_TYPE=Debug   # for debug build
 ```
 
 ```bash

--- a/include/espresso.hxx
+++ b/include/espresso.hxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright © 1993-2025, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/include/espresso/Arg.hxx
+++ b/include/espresso/Arg.hxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright ï¿½1993-20250, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/include/espresso/Arg.inl
+++ b/include/espresso/Arg.inl
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (donnacha.forde@simply-components.com)           
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright ï¿½1993-20250, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/include/espresso/ArgManager.hxx
+++ b/include/espresso/ArgManager.hxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright ï¿½ 1993-2025, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/include/espresso/ArgManagerFactory.hxx
+++ b/include/espresso/ArgManagerFactory.hxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright ï¿½1993-20250, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/include/espresso/Args.hxx
+++ b/include/espresso/Args.hxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright ï¿½1993-20250, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/include/espresso/IArgMgr.hxx
+++ b/include/espresso/IArgMgr.hxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright ï¿½1993-20250, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/include/espresso/IArgRenderer.hxx
+++ b/include/espresso/IArgRenderer.hxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright ï¿½1993-20250, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/include/espresso/StdoutArgRenderer.hxx
+++ b/include/espresso/StdoutArgRenderer.hxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright ï¿½1993-20250, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/include/espresso/StopWatch.hxx
+++ b/include/espresso/StopWatch.hxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright ï¿½1993-20250, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/include/espresso/strings.hxx
+++ b/include/espresso/strings.hxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright ï¿½1993-20250, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/include/espresso/sys.hxx
+++ b/include/espresso/sys.hxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright ï¿½1993-20250, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/include/espresso/threads.hxx
+++ b/include/espresso/threads.hxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright � 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright � 1993-2025, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/src/Arg.cxx
+++ b/src/Arg.cxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright ï¿½1993-20250, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/src/ArgManager.cxx
+++ b/src/ArgManager.cxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright � 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright � 1993-2025, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/src/ArgManagerFactory.cxx
+++ b/src/ArgManagerFactory.cxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright ï¿½1993-20250, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/src/Args.cxx
+++ b/src/Args.cxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright ï¿½1993-20250, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.
@@ -924,7 +924,7 @@ string Args::getCopyrightNotice() const
 	
 	if (!m_strCopyrightOwner.empty() && !m_strCopyrightYear.empty())
 	{
-		//strCopyrightNotice = "Copyright© ";
+		//strCopyrightNotice = "Copyrightï¿½ ";
 		strCopyrightNotice = "Copyright ";
 		strCopyrightNotice += m_strCopyrightYear;
 		strCopyrightNotice += ", ";

--- a/src/IArgMgr.cxx
+++ b/src/IArgMgr.cxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright ï¿½1993-20250, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/src/IArgRenderer.cxx
+++ b/src/IArgRenderer.cxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright ï¿½1993-20250, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/src/StdoutArgRenderer.cxx
+++ b/src/StdoutArgRenderer.cxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright � 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright � 1993-2025, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/src/StdoutArgRenderer.cxx
+++ b/src/StdoutArgRenderer.cxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright ï¿½ 1993-2020, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.
@@ -163,14 +163,17 @@ void StdoutArgRenderer::onRequestInfo(const Args& args)
 																					<< endl;
 	}
 
+	// @todo Only provide this info when some other flag is set - e.g. --verbose or --info-detailed
+	// cout << "Built using the espresso library, Version " << sys::getBuildVersion()
+	// 	 << " - compiled at " << __TIME__ << " " << __DATE__ << "."					<< endl
+	// 	 << "https://github.com/donnachaforde/espresso/releases"					<< endl
+	// 																				<< endl
+	// 	 << args.getBugReportingInstructions()										<< endl
+	// 																				<< endl
+	// 	 << args.getCopyrightNotice()												<< endl;
 
-	cout << "Built using the espresso library, Version " << sys::getBuildVersion()
-		 << " - compiled at " << __TIME__ << " " << __DATE__ << "."					<< endl
-		 << "https://github.com/donnachaforde/espresso/releases"					<< endl
-																					<< endl
-		 << args.getBugReportingInstructions()										<< endl
-																					<< endl
-		 << args.getCopyrightNotice()												<< endl;
+
+	cout << args.getBugReportingInstructions() << " " << args.getCopyrightNotice()	<< endl;
 
 	return;
 }

--- a/src/StopWatch.cxx
+++ b/src/StopWatch.cxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright ï¿½1993-20250, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/src/espresso.cxx
+++ b/src/espresso.cxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright ï¿½1993-20250, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/src/stdhdr.cxx
+++ b/src/stdhdr.cxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright ï¿½1993-20250, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/src/stdhdr.hxx
+++ b/src/stdhdr.hxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright ï¿½1993-20250, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/src/stdhdr.hxx
+++ b/src/stdhdr.hxx
@@ -133,7 +133,7 @@ namespace espresso
 	};
 
 
-	static const char* BUILD_VERSION = "0.10.1.102-beta";
+	static const char* BUILD_VERSION = "0.11.1.0-beta";
 }
 
 

--- a/src/strings.cxx
+++ b/src/strings.cxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright ï¿½1993-20250, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/src/sys.cxx
+++ b/src/sys.cxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright © 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright ï¿½1993-20250, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.

--- a/src/threads.cxx
+++ b/src/threads.cxx
@@ -6,7 +6,7 @@
 //
 // Developed by Donnacha Forde (@DonnachaForde)
 //
-// Copyright � 1993-2020, Donnacha Forde. All rights reserved.
+// Copyright � 1993-2025, Donnacha Forde. All rights reserved.
 //
 //
 // This software is provided 'as is' without warranty, expressed or implied.


### PR DESCRIPTION
The main changes are:

* Tighten up cmake install so that no gtest/gmake components are tagged along with the install. 
* Updated `--info` switch output to remove internal details of espresso (will use an alternative switch in a future release).
* Updated copyright dates